### PR TITLE
Exclude primitive type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ plugins {
 
 dependencies {
     ...
-    archUnitExtraLib('io.github.footaku:erai:0.0.2')
+    archUnitExtraLib('io.github.footaku:erai:0.0.3')
     ...
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.github.footaku"
-version = "0.0.2"
+version = "0.0.3"
 
 repositories {
     mavenLocal()
@@ -73,7 +73,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "io.github.footaku"
             artifactId = "erai"
-            version = "0.0.2"
+            version = "0.0.3"
 
             pom {
                 name.set("erai")

--- a/src/main/java/io/github/footaku/erai/rule/ShouldBeIndicateReturnValueNullability.java
+++ b/src/main/java/io/github/footaku/erai/rule/ShouldBeIndicateReturnValueNullability.java
@@ -27,6 +27,7 @@ public class ShouldBeIndicateReturnValueNullability implements ArchRuleTest {
         var rule = ArchRuleDefinition.methods()
             .that(isNotExcludedClass)
             .and(hasReturnValue)
+            .and(isReturnBoxingType)
             .and(isNotGeneratedCode)
             .and(isNotOverrideBasicMethod)
             .should(beAnnotatedWith)
@@ -50,6 +51,15 @@ public class ShouldBeIndicateReturnValueNullability implements ArchRuleTest {
             public boolean test(JavaMethod input) {
                 var returnTYpe = input.getReturnType().toErasure();
                 return !returnTYpe.getName().equals("void");
+            }
+        };
+
+    DescribedPredicate<JavaMethod> isReturnBoxingType =
+        new DescribedPredicate<>("is return boxing type") {
+            @Override
+            public boolean test(JavaMethod input) {
+                var returnTYpe = input.getReturnType().toErasure();
+                return !returnTYpe.isPrimitive();
             }
         };
 

--- a/src/test/java/com/example/footaku/NormalClass.java
+++ b/src/test/java/com/example/footaku/NormalClass.java
@@ -51,4 +51,8 @@ public class NormalClass {
     public String annotatedWithSpringNullable() {
         return "Hello, world";
     }
+
+    public int primitiveTypeNeedNotAnnotations() {
+        return -1;
+    }
 }

--- a/src/test/java/io/github/footaku/erai/ShouldBeIndicateReturnValueNullabilityTest.java
+++ b/src/test/java/io/github/footaku/erai/ShouldBeIndicateReturnValueNullabilityTest.java
@@ -1,7 +1,7 @@
 package io.github.footaku.erai;
 
-import io.github.footaku.erai.rule.ShouldBeIndicateReturnValueNullability;
 import com.societegenerale.commons.plugin.utils.ArchUtils;
+import io.github.footaku.erai.rule.ShouldBeIndicateReturnValueNullability;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,6 @@ class ShouldBeIndicateReturnValueNullabilityTest {
         });
 
         Assertions.assertThat(th).isInstanceOf(AssertionError.class).hasMessageContaining("was violated (2 times)");
-
     }
 
     @Test


### PR DESCRIPTION
- close #2 

Primitive types can not return null.
So, annotations don't need.